### PR TITLE
Normalize spacing and heading styling

### DIFF
--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -60,7 +60,7 @@ export default function Calendar(): JSX.Element {
     const eventRows = mapEventsToCalendarRows()
 
     return (
-        <Card mt="9">
+        <Card mb="9">
             <Flex direction="column" justify="center" p="5">
                 <Heading
                     align="center"

--- a/src/components/Forms/Event/index.tsx
+++ b/src/components/Forms/Event/index.tsx
@@ -51,8 +51,6 @@ export default function EventForm({
 
     return (
         <FormLayout maxWidth="max-w-md" isLoading={isLoading} hasCard={true}>
-            <Heading>Book Your Gig</Heading>
-            <Separator size="4" mb="5" />
             <Form.Root onSubmit={submit}>
                 <Flex direction="column" gap="3">
                     <Input

--- a/src/components/RecurringGigs/index.tsx
+++ b/src/components/RecurringGigs/index.tsx
@@ -44,7 +44,7 @@ export default function RecurringGigs({ cmsData }: Props) {
     }
 
     return (
-        <Container py="7">
+        <Container>
             <Box>
                 {Object.entries(days).map(([day, gigs]) => {
                     if (gigs.length) {

--- a/src/components/SearchContainer/index.tsx
+++ b/src/components/SearchContainer/index.tsx
@@ -54,8 +54,8 @@ export default function SearchContainer({
     )
 
     return (
-        <Container size="4">
-            <Card>
+        <Card>
+            <Box p="3">
                 <Heading mb="3" ml="3">
                     {heading}
                 </Heading>
@@ -82,7 +82,7 @@ export default function SearchContainer({
                         />
                     </Box>
                 )}
-            </Card>
-        </Container>
+            </Box>
+        </Card>
     )
 }

--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -32,7 +32,11 @@ export default function AdminLayout({
                     headerType={HeaderType.Admin}
                     showLinks={showHeaderLinks}
                 />
-                <Container size="3" className="flex-grow overflow-x-hidden">
+                <Container
+                    size="3"
+                    className="flex-grow overflow-x-hidden"
+                    py="7"
+                >
                     {session ? (
                         children
                     ) : (

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
                 {fullWidth ? (
                     children
                 ) : (
-                    <Container size="3" className="flex-grow">
+                    <Container size="3" className="flex-grow" py="7">
                         {children}
                     </Container>
                 )}

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -69,7 +69,7 @@ export default function About({
     return (
         <RootLayout pageTitle="Jazz In Toronto | About Us">
             <Flex direction="column" align="center" width="100%" mx="auto">
-                <Heading mb="5" align="center">
+                <Heading mb="9" align="center" size="9">
                     {cmsData?.heading}
                 </Heading>
                 <Text

--- a/src/pages/admin/artists.tsx
+++ b/src/pages/admin/artists.tsx
@@ -1,4 +1,5 @@
 // Componentsj
+import { Heading } from '@radix-ui/themes'
 import AdminLayout from '~/layouts/AdminLayout'
 import SearchContainer from '~/components/SearchContainer'
 import Loading from '~/components/Loading'
@@ -20,6 +21,9 @@ export default function AdminArtists() {
     return (
         <AdminLayout pageTitle="Jazz In Toronto | Admin - artists">
             <>
+                <Heading align="center" size="9" mb="9">
+                    Artists
+                </Heading>
                 {artists && !artistsLoading && (
                     <SearchContainer
                         data={{ type: DataType.ARTIST, items: artists }}

--- a/src/pages/admin/events.tsx
+++ b/src/pages/admin/events.tsx
@@ -5,6 +5,7 @@ import EventScraper from '~/components/Forms/EventScraper'
 import { Container, Tabs } from '@radix-ui/themes'
 import SearchApproveEvents from '~/components/SearchApproveEvents'
 import SearchEvents from '~/components/SearchEvents'
+import { Heading } from '@radix-ui/themes'
 
 enum View {
     Search = 'Search',
@@ -16,6 +17,9 @@ enum View {
 export default function AdminEvents(): JSX.Element {
     return (
         <AdminLayout pageTitle="Jazz In Toronto | Admin - Events">
+            <Heading align="center" size="9" mb="9">
+                Events
+            </Heading>
             <Tabs.Root defaultValue={View.Search}>
                 <Tabs.List>
                     <Tabs.Trigger value={View.Search}>Search</Tabs.Trigger>

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -12,7 +12,7 @@ export default function AdminHome() {
 
     return (
         <AdminLayout pageTitle="Jazz In Toronto | Admin - Bands">
-            <Heading mt="2" mb="7" align="center">
+            <Heading mt="2" mb="9" align="center" size="9">
                 Dashboard
             </Heading>
             {isLoading && <Loading />}

--- a/src/pages/admin/venues.tsx
+++ b/src/pages/admin/venues.tsx
@@ -1,6 +1,7 @@
 // Components
 import AdminLayout from '~/layouts/AdminLayout'
 import SearchContainer from '~/components/SearchContainer'
+import { Heading } from '@radix-ui/themes'
 // Utils
 import { api } from '~/utils/api'
 import { DataType } from '~/types/enums'
@@ -16,6 +17,9 @@ export default function AdminVenues() {
     return (
         <AdminLayout pageTitle="Jazz In Toronto | Admin - Venues">
             <>
+                <Heading align="center" size="9" mb="9">
+                    Venues
+                </Heading>
                 {events && !isLoading && (
                     <SearchContainer
                         data={{ type: DataType.VENUE, items: events }}

--- a/src/pages/book.tsx
+++ b/src/pages/book.tsx
@@ -3,12 +3,17 @@ import RootLayout from '~/layouts/RootLayout'
 import EventForm from '~/components/Forms/Event'
 // Hooks
 import useEventForm from '~/components/Forms/Event/hooks/useEventForm'
+import { Heading } from '@radix-ui/themes'
 
 export default function Book(): JSX.Element {
     const eventFormProps = useEventForm()
 
     return (
         <RootLayout pageTitle="Jazz In Toronto | Book Your Event">
+            <Heading align="center" size="9" mb="9">
+                Book your gig here!
+            </Heading>
+
             <EventForm {...eventFormProps} />
         </RootLayout>
     )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,9 +16,9 @@ import {
 export default function Home() {
     return (
         <RootLayout pageTitle="Jazz In Toronto | Home" fullWidth={true}>
-            <Box p="7">
+            <Box pb="7">
                 <Container size="3" className="flex-grow" py="8">
-                    <Heading size="8" mb="6" align="center">
+                    <Heading size="9" mb="6" align="center">
                         We are JAZZINTORONTO
                     </Heading>
                     <Text size="6">

--- a/src/pages/listings.tsx
+++ b/src/pages/listings.tsx
@@ -51,13 +51,13 @@ export default function Listings({
 }: InferGetStaticPropsType<typeof getStaticProps>): JSX.Element {
     return (
         <RootLayout pageTitle="Jazz In Toronto | Event Listings">
-            <Heading size="9" mt="8">
+            <Heading size="9" align="center" mb="9">
                 Listings
             </Heading>
             <Calendar />
             {data && (
                 <>
-                    <Heading size="9" mt="8">
+                    <Heading size="9" align="center" mb="9">
                         Recurring Gigs
                     </Heading>
                     <RecurringGigs cmsData={data} />

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -7,7 +7,9 @@ export default function PrivacyPolicy() {
     return (
         <RootLayout pageTitle="Jazz In Toronto | Privacy Policy">
             <Container>
-                <Heading>Privacy Policy</Heading>
+                <Heading align="center" mb="6" size="9">
+                    Privacy Policy
+                </Heading>
                 <Text>
                     <br />
                     Last updated: August 1st, 2023
@@ -23,6 +25,7 @@ export default function PrivacyPolicy() {
                     Service. By using the Service, you agree to the collection
                     and use of information in accordance with this policy.
                 </Text>
+                <br />
                 <br />
                 <Heading size="2">Information Collection and Use</Heading>
                 <Text as="p">
@@ -46,6 +49,7 @@ export default function PrivacyPolicy() {
                     time spent on those pages and other statistics.
                 </Text>
                 <br />
+                <br />
                 <Heading size="2">Cookies</Heading>
                 <Text>
                     <br />
@@ -62,6 +66,7 @@ export default function PrivacyPolicy() {
                     we recommend that you leave them turned on.
                 </Text>
                 <br />
+                <br />
                 <Heading size="2">Service Providers</Heading>
                 <Text>
                     <br />
@@ -73,6 +78,7 @@ export default function PrivacyPolicy() {
                     specific tasks on our behalf and are obligated not to
                     disclose or use your information for any other purpose.
                 </Text>
+                <br />
                 <br />
                 <Heading size="2">Security</Heading>
                 <Text>
@@ -89,6 +95,7 @@ export default function PrivacyPolicy() {
                     we have collected from you.
                 </Text>
                 <br />
+                <br />
                 <Heading size="2">Links to Other Sites</Heading>
                 <Text>
                     <br />
@@ -101,6 +108,7 @@ export default function PrivacyPolicy() {
                     assume no responsibility for the content, privacy policies,
                     or practices of any third-party sites or services.
                 </Text>
+                <br />
                 <br />
                 <Heading size="2">Changes to This Privacy Policy</Heading>
                 <Text>

--- a/src/pages/venues.tsx
+++ b/src/pages/venues.tsx
@@ -20,12 +20,10 @@ export default function Venues(): JSX.Element {
 
     return (
         <RootLayout pageTitle="Jazz In Toronto | Venues">
+            <Heading mb="5" align="center" size="9">
+                Venues
+            </Heading>
             <Flex direction="column" my="9">
-                <Flex mx="2">
-                    <Heading mb="5" align="center">
-                        Venue listings
-                    </Heading>
-                </Flex>
                 {venueCards}
             </Flex>
         </RootLayout>


### PR DESCRIPTION
closes #9 

- added extra breaks in `/privacy-policy`
- normalized heading margin and size - favoring adding margin to the bottom of elements for spacing
- removed top padding/margin on certain elements
- remove unnecessary container from search table and add inner div with padding
- Add padding to layouts
- Add heading to book form page