### PR TITLE
feat/show-event-name

### DIFF
--- a/src/components/Calendar/components/ModalDay.tsx
+++ b/src/components/Calendar/components/ModalDay.tsx
@@ -27,7 +27,7 @@ export default function ModalDay({ dailyEvents: { date, events } }: Props) {
                                 <span className="mr-6">
                                     {`${getFormattedTime(event.startDate)}`}
                                 </span>
-                                <span>{event.artist.name}</span>
+                                <span>{event.name}</span>
                             </Table.Cell>
                         </Table.Row>
                     )

--- a/src/components/DailyListings/DailyListings.tsx
+++ b/src/components/DailyListings/DailyListings.tsx
@@ -36,7 +36,7 @@ export default function DailyListings({ selectedDate }: Props) {
                 cell: (info) => info.getValue(),
                 enableColumnFilter: false
             }),
-            columnHelper.accessor((row) => row.artist.name, {
+            columnHelper.accessor((row) => row.name, {
                 header: 'Artist',
                 cell: (info) => info.getValue(),
                 enableColumnFilter: false

--- a/src/components/EventsMap/EventsMap.tsx
+++ b/src/components/EventsMap/EventsMap.tsx
@@ -5,7 +5,7 @@ import { api } from '~/utils/api'
 import startOfDay from 'date-fns/startOfDay'
 import { Flex, Text } from '@radix-ui/themes'
 import { EventWithArtistVenue } from '~/types/data'
-import { EventsMapModal } from './components'
+import { EventsMapOverlay } from './components'
 
 /**
  * Props for the EventsMap component
@@ -77,7 +77,7 @@ export const EventsMap = ({ selectedDate }: Props) => {
                             />
                         ))}
                         {showModal && (
-                            <EventsMapModal
+                            <EventsMapOverlay
                                 {...modalContent}
                                 onClose={() => setShowModal(false)}
                             />

--- a/src/components/EventsMap/components/EventsMapOverlay.tsx
+++ b/src/components/EventsMap/components/EventsMapOverlay.tsx
@@ -9,7 +9,7 @@ type Props = {
     onClose: () => void
 }
 
-export function EventsMapModal({ venueName, events, onClose }: Props) {
+export function EventsMapOverlay({ venueName, events, onClose }: Props) {
     return (
         <Flex
             position="relative"
@@ -31,7 +31,7 @@ export function EventsMapModal({ venueName, events, onClose }: Props) {
             <Heading mb="3">{`Today @ ${venueName}`}</Heading>
             <Flex direction="column">
                 {events.map((event) => (
-                    <Flex key={event.id}>{`${event.artist.name} @ ${format(
+                    <Flex key={event.id}>{`${event.name} @ ${format(
                         event.startDate,
                         'h:mm a'
                     )}`}</Flex>

--- a/src/components/EventsMap/components/index.ts
+++ b/src/components/EventsMap/components/index.ts
@@ -1,1 +1,1 @@
-export { EventsMapModal } from './EventsMapModal'
+export { EventsMapOverlay } from './EventsMapOverlay'

--- a/src/components/Tables/Events.tsx
+++ b/src/components/Tables/Events.tsx
@@ -149,6 +149,10 @@ export function EventsTable() {
                 cell: (info) => info.getValue(),
                 header: 'Event'
             }),
+            columnHelper.accessor((row) => row.artist.name, {
+                cell: (info) => info.getValue(),
+                header: 'Artist'
+            }),
             columnHelper.accessor((row) => row.venue.name, {
                 cell: (info) => info.getValue(),
                 header: 'Venue'


### PR DESCRIPTION
Show the event name by default and not the artist name in public pages. Add artist name column to events table.